### PR TITLE
Update droidimg.py

### DIFF
--- a/droidimg.py
+++ b/droidimg.py
@@ -176,6 +176,8 @@ def do_guess_start_address(kallsyms, vmlinux):
             for i in xrange(0,0x100000,step):
                 _startaddr_from_processor = addr_base + i
                 fileoffset = lookup_processor_addr - _startaddr_from_processor
+                if fileoffset > len(vmlinux):
+                        break
                 if lookup_processor_addr == INT(fileoffset, vmlinux):
                     break
 


### PR DESCRIPTION
fix bug:

[+]kallsyms_arch =  32
[+]kallsyms_address_table =  0xa39750
[+]kallsyms_num =  85715 85715
[+]kallsyms_name_table =  0xa8d2b0
[+]kallsyms_type_table =  0x0
[+]kallsyms_marker_table =  0xb97bf0
[+]kallsyms_token_table =  0xb98130
[+]kallsyms_token_index_table =  0xb984a0
Traceback (most recent call last):
  File "droidimg.py", line 380, in <module>
    main(sys.argv)
  File "droidimg.py", line 371, in main
    do_kallsyms(kallsyms, vmlinux)
  File "droidimg.py", line 257, in do_kallsyms
    do_guess_start_address(kallsyms, vmlinux)
  File "droidimg.py", line 181, in do_guess_start_address
    if lookup_processor_addr == INT(fileoffset, vmlinux):
  File "droidimg.py", line 32, in INT
    (num,) = struct.unpack(f, s)
struct.error: unpack requires a string argument of length 4

P.S. failed to upload test vmlinux to github :(
