### PR TITLE
Support GKI kernel (typically 5.0+)

### DIFF
--- a/vmlinux.py
+++ b/vmlinux.py
@@ -935,7 +935,7 @@ def find_ksymtab(kallsyms, vmlinux):
     except:
         pass
 
-    while idx < (len(vmlinux) - step):
+    while idx < (len(vmlinux) - step*2):
         if is_ksymtab_pair(kallsyms, vmlinux, idx, symlist):
             ksym_count += 1
             idx += (step * 2)


### PR DESCRIPTION
Passed test on version 5 and 6 kernels of Snapdragon, MTK and Kirin devices.